### PR TITLE
Add automated deployment to WP SVN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  tag:
+    name: Release on new tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: wp-szechenyi2020-infoblokk


### PR DESCRIPTION
The process uses GitHub actions to fetch the newly pushed git tag and release it to WP SVN

Note:
In order to make it work, please set up the `SVN_PASSWORD` and `SVN_USERNAME` secrets on this repository's settings page.

refs #11